### PR TITLE
corrected file sharing exception and limit checklist appending

### DIFF
--- a/CreateWordFind.Designer.cs
+++ b/CreateWordFind.Designer.cs
@@ -72,31 +72,35 @@
             // 
             this.WordList.ContextMenuStrip = this.wordlistContextMenu;
             this.WordList.FormattingEnabled = true;
-            this.WordList.Location = new System.Drawing.Point(25, 39);
+            this.WordList.ItemHeight = 37;
+            this.WordList.Location = new System.Drawing.Point(79, 111);
+            this.WordList.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.WordList.Name = "WordList";
-            this.WordList.Size = new System.Drawing.Size(120, 160);
+            this.WordList.Size = new System.Drawing.Size(371, 448);
             this.WordList.TabIndex = 0;
             this.WordList.MouseMove += new System.Windows.Forms.MouseEventHandler(this.WordList_MouseMove);
             // 
             // wordlistContextMenu
             // 
+            this.wordlistContextMenu.ImageScalingSize = new System.Drawing.Size(48, 48);
             this.wordlistContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem});
             this.wordlistContextMenu.Name = "wordlistContextMenu";
-            this.wordlistContextMenu.Size = new System.Drawing.Size(103, 26);
+            this.wordlistContextMenu.Size = new System.Drawing.Size(182, 60);
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(102, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(181, 56);
             this.copyToolStripMenuItem.Text = "Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.CopyToolStripMenuItem_Click);
             // 
             // addButton
             // 
-            this.addButton.Location = new System.Drawing.Point(151, 206);
+            this.addButton.Location = new System.Drawing.Point(478, 586);
+            this.addButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.addButton.Name = "addButton";
-            this.addButton.Size = new System.Drawing.Size(75, 23);
+            this.addButton.Size = new System.Drawing.Size(238, 65);
             this.addButton.TabIndex = 4;
             this.addButton.Text = "Add";
             this.addButton.UseVisualStyleBackColor = true;
@@ -105,9 +109,10 @@
             // 
             // modifyButton
             // 
-            this.modifyButton.Location = new System.Drawing.Point(151, 116);
+            this.modifyButton.Location = new System.Drawing.Point(478, 330);
+            this.modifyButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.modifyButton.Name = "modifyButton";
-            this.modifyButton.Size = new System.Drawing.Size(75, 23);
+            this.modifyButton.Size = new System.Drawing.Size(238, 65);
             this.modifyButton.TabIndex = 2;
             this.modifyButton.Text = "Modify";
             this.modifyButton.UseVisualStyleBackColor = true;
@@ -116,9 +121,10 @@
             // 
             // removeButton
             // 
-            this.removeButton.Location = new System.Drawing.Point(151, 71);
+            this.removeButton.Location = new System.Drawing.Point(478, 202);
+            this.removeButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.removeButton.Name = "removeButton";
-            this.removeButton.Size = new System.Drawing.Size(75, 23);
+            this.removeButton.Size = new System.Drawing.Size(238, 65);
             this.removeButton.TabIndex = 1;
             this.removeButton.Text = "Remove";
             this.removeButton.UseVisualStyleBackColor = true;
@@ -130,9 +136,10 @@
             this.left_right_check.AutoSize = true;
             this.left_right_check.Checked = true;
             this.left_right_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.left_right_check.Location = new System.Drawing.Point(269, 199);
+            this.left_right_check.Location = new System.Drawing.Point(852, 566);
+            this.left_right_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.left_right_check.Name = "left_right_check";
-            this.left_right_check.Size = new System.Drawing.Size(84, 17);
+            this.left_right_check.Size = new System.Drawing.Size(235, 41);
             this.left_right_check.TabIndex = 8;
             this.left_right_check.Text = "Left to Right";
             this.left_right_check.UseVisualStyleBackColor = true;
@@ -142,9 +149,10 @@
             this.right_left_check.AutoSize = true;
             this.right_left_check.Checked = true;
             this.right_left_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.right_left_check.Location = new System.Drawing.Point(269, 222);
+            this.right_left_check.Location = new System.Drawing.Point(852, 632);
+            this.right_left_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.right_left_check.Name = "right_left_check";
-            this.right_left_check.Size = new System.Drawing.Size(84, 17);
+            this.right_left_check.Size = new System.Drawing.Size(235, 41);
             this.right_left_check.TabIndex = 10;
             this.right_left_check.Text = "Right to Left";
             this.right_left_check.UseVisualStyleBackColor = true;
@@ -154,9 +162,10 @@
             this.top_bottom_check.AutoSize = true;
             this.top_bottom_check.Checked = true;
             this.top_bottom_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.top_bottom_check.Location = new System.Drawing.Point(269, 245);
+            this.top_bottom_check.Location = new System.Drawing.Point(852, 697);
+            this.top_bottom_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.top_bottom_check.Name = "top_bottom_check";
-            this.top_bottom_check.Size = new System.Drawing.Size(93, 17);
+            this.top_bottom_check.Size = new System.Drawing.Size(266, 41);
             this.top_bottom_check.TabIndex = 12;
             this.top_bottom_check.Text = "Top to Bottom";
             this.top_bottom_check.UseVisualStyleBackColor = true;
@@ -166,9 +175,10 @@
             this.bottom_top_check.AutoSize = true;
             this.bottom_top_check.Checked = true;
             this.bottom_top_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.bottom_top_check.Location = new System.Drawing.Point(269, 268);
+            this.bottom_top_check.Location = new System.Drawing.Point(852, 763);
+            this.bottom_top_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.bottom_top_check.Name = "bottom_top_check";
-            this.bottom_top_check.Size = new System.Drawing.Size(93, 17);
+            this.bottom_top_check.Size = new System.Drawing.Size(266, 41);
             this.bottom_top_check.TabIndex = 14;
             this.bottom_top_check.Text = "Bottom to Top";
             this.bottom_top_check.UseVisualStyleBackColor = true;
@@ -178,9 +188,10 @@
             this.topleft_bottomright_check.AutoSize = true;
             this.topleft_bottomright_check.Checked = true;
             this.topleft_bottomright_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.topleft_bottomright_check.Location = new System.Drawing.Point(379, 199);
+            this.topleft_bottomright_check.Location = new System.Drawing.Point(1200, 566);
+            this.topleft_bottomright_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.topleft_bottomright_check.Name = "topleft_bottomright_check";
-            this.topleft_bottomright_check.Size = new System.Drawing.Size(142, 17);
+            this.topleft_bottomright_check.Size = new System.Drawing.Size(411, 41);
             this.topleft_bottomright_check.TabIndex = 9;
             this.topleft_bottomright_check.Text = "Top Left to Bottom Right";
             this.topleft_bottomright_check.UseVisualStyleBackColor = true;
@@ -190,9 +201,10 @@
             this.bottomleft_topright_check.AutoSize = true;
             this.bottomleft_topright_check.Checked = true;
             this.bottomleft_topright_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.bottomleft_topright_check.Location = new System.Drawing.Point(379, 222);
+            this.bottomleft_topright_check.Location = new System.Drawing.Point(1200, 632);
+            this.bottomleft_topright_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.bottomleft_topright_check.Name = "bottomleft_topright_check";
-            this.bottomleft_topright_check.Size = new System.Drawing.Size(142, 17);
+            this.bottomleft_topright_check.Size = new System.Drawing.Size(411, 41);
             this.bottomleft_topright_check.TabIndex = 11;
             this.bottomleft_topright_check.Text = "Bottom Left to Top Right";
             this.bottomleft_topright_check.UseVisualStyleBackColor = true;
@@ -202,9 +214,10 @@
             this.topright_bottomleft_check.AutoSize = true;
             this.topright_bottomleft_check.Checked = true;
             this.topright_bottomleft_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.topright_bottomleft_check.Location = new System.Drawing.Point(379, 245);
+            this.topright_bottomleft_check.Location = new System.Drawing.Point(1200, 697);
+            this.topright_bottomleft_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.topright_bottomleft_check.Name = "topright_bottomleft_check";
-            this.topright_bottomleft_check.Size = new System.Drawing.Size(142, 17);
+            this.topright_bottomleft_check.Size = new System.Drawing.Size(411, 41);
             this.topright_bottomleft_check.TabIndex = 13;
             this.topright_bottomleft_check.Text = "Top Right to Bottom Left";
             this.topright_bottomleft_check.UseVisualStyleBackColor = true;
@@ -214,9 +227,10 @@
             this.bottomright_topleft_check.AutoSize = true;
             this.bottomright_topleft_check.Checked = true;
             this.bottomright_topleft_check.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.bottomright_topleft_check.Location = new System.Drawing.Point(379, 268);
+            this.bottomright_topleft_check.Location = new System.Drawing.Point(1200, 763);
+            this.bottomright_topleft_check.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.bottomright_topleft_check.Name = "bottomright_topleft_check";
-            this.bottomright_topleft_check.Size = new System.Drawing.Size(142, 17);
+            this.bottomright_topleft_check.Size = new System.Drawing.Size(411, 41);
             this.bottomright_topleft_check.TabIndex = 15;
             this.bottomright_topleft_check.Text = "Bottom Right to Top Left";
             this.bottomright_topleft_check.UseVisualStyleBackColor = true;
@@ -225,9 +239,10 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(335, 180);
+            this.label1.Location = new System.Drawing.Point(1061, 512);
+            this.label1.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(106, 16);
+            this.label1.Size = new System.Drawing.Size(313, 44);
             this.label1.TabIndex = 13;
             this.label1.Text = "Position Settings";
             // 
@@ -235,25 +250,27 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(44, 20);
+            this.label2.Location = new System.Drawing.Point(139, 57);
+            this.label2.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(63, 16);
+            this.label2.Size = new System.Drawing.Size(185, 44);
             this.label2.TabIndex = 14;
             this.label2.Text = "Word List";
             // 
             // HeightPanel
             // 
-            this.HeightPanel.Location = new System.Drawing.Point(352, 89);
+            this.HeightPanel.Location = new System.Drawing.Point(1115, 253);
+            this.HeightPanel.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.HeightPanel.Minimum = new decimal(new int[] {
             15,
             0,
             0,
             0});
             this.HeightPanel.Name = "HeightPanel";
-            this.HeightPanel.Size = new System.Drawing.Size(120, 20);
+            this.HeightPanel.Size = new System.Drawing.Size(380, 44);
             this.HeightPanel.TabIndex = 6;
             this.HeightPanel.Value = new decimal(new int[] {
-            25,
+            16,
             0,
             0,
             0});
@@ -262,24 +279,27 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(286, 58);
+            this.label3.Location = new System.Drawing.Point(906, 165);
+            this.label3.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(218, 16);
+            this.label3.Size = new System.Drawing.Size(650, 44);
             this.label3.TabIndex = 16;
             this.label3.Text = "Grid Dimensions (Character Length)";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(305, 91);
+            this.label4.Location = new System.Drawing.Point(966, 259);
+            this.label4.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(41, 13);
+            this.label4.Size = new System.Drawing.Size(118, 37);
             this.label4.TabIndex = 17;
             this.label4.Text = "Height:";
             // 
             // WidthPanel
             // 
-            this.WidthPanel.Location = new System.Drawing.Point(352, 124);
+            this.WidthPanel.Location = new System.Drawing.Point(1115, 353);
+            this.WidthPanel.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.WidthPanel.Maximum = new decimal(new int[] {
             500,
             0,
@@ -291,10 +311,10 @@
             0,
             0});
             this.WidthPanel.Name = "WidthPanel";
-            this.WidthPanel.Size = new System.Drawing.Size(120, 20);
+            this.WidthPanel.Size = new System.Drawing.Size(380, 44);
             this.WidthPanel.TabIndex = 7;
             this.WidthPanel.Value = new decimal(new int[] {
-            25,
+            16,
             0,
             0,
             0});
@@ -302,17 +322,19 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(305, 126);
+            this.label5.Location = new System.Drawing.Point(966, 359);
+            this.label5.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(38, 13);
+            this.label5.Size = new System.Drawing.Size(109, 37);
             this.label5.TabIndex = 19;
             this.label5.Text = "Width:";
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(289, 305);
+            this.saveButton.Location = new System.Drawing.Point(915, 868);
+            this.saveButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(75, 23);
+            this.saveButton.Size = new System.Drawing.Size(238, 65);
             this.saveButton.TabIndex = 16;
             this.saveButton.Text = "Save...";
             this.saveButton.UseVisualStyleBackColor = true;
@@ -321,9 +343,10 @@
             // 
             // loadButton
             // 
-            this.loadButton.Location = new System.Drawing.Point(397, 305);
+            this.loadButton.Location = new System.Drawing.Point(1257, 868);
+            this.loadButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.loadButton.Name = "loadButton";
-            this.loadButton.Size = new System.Drawing.Size(75, 23);
+            this.loadButton.Size = new System.Drawing.Size(238, 65);
             this.loadButton.TabIndex = 17;
             this.loadButton.Text = "Load...";
             this.loadButton.UseVisualStyleBackColor = true;
@@ -332,9 +355,10 @@
             // 
             // GenerateButton
             // 
-            this.GenerateButton.Location = new System.Drawing.Point(21, 277);
+            this.GenerateButton.Location = new System.Drawing.Point(66, 788);
+            this.GenerateButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.GenerateButton.Name = "GenerateButton";
-            this.GenerateButton.Size = new System.Drawing.Size(133, 44);
+            this.GenerateButton.Size = new System.Drawing.Size(421, 125);
             this.GenerateButton.TabIndex = 5;
             this.GenerateButton.Text = "Generate Puzzle";
             this.GenerateButton.UseVisualStyleBackColor = true;
@@ -343,9 +367,10 @@
             // 
             // wordTextBox
             // 
-            this.wordTextBox.Location = new System.Drawing.Point(25, 206);
+            this.wordTextBox.Location = new System.Drawing.Point(79, 586);
+            this.wordTextBox.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.wordTextBox.Name = "wordTextBox";
-            this.wordTextBox.Size = new System.Drawing.Size(120, 20);
+            this.wordTextBox.Size = new System.Drawing.Size(371, 44);
             this.wordTextBox.TabIndex = 3;
             this.wordTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.WordTextBox_KeyDown);
             this.wordTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.WordTextBox_KeyPress);
@@ -356,9 +381,11 @@
             // 
             // CreateWordFind
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(19F, 37F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(578, 386);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(1830, 1099);
             this.Controls.Add(this.wordTextBox);
             this.Controls.Add(this.GenerateButton);
             this.Controls.Add(this.loadButton);
@@ -382,6 +409,7 @@
             this.Controls.Add(this.modifyButton);
             this.Controls.Add(this.addButton);
             this.Controls.Add(this.WordList);
+            this.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.Name = "CreateWordFind";
             this.Text = "Create Word Find";
             this.wordlistContextMenu.ResumeLayout(false);

--- a/CreateWordFind.cs
+++ b/CreateWordFind.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Windows.Forms;
 using System.IO;
+using System.Windows.Forms;
+//using System.Xml.Linq;
 
 namespace Wordfind_Generator
 {
@@ -10,6 +11,7 @@ namespace Wordfind_Generator
     {
         BindingList<string> _words;
         List<bool> _checklist;
+        public string serialNumberString;
 
         public CreateWordFind()
         {
@@ -18,6 +20,8 @@ namespace Wordfind_Generator
 
             InitializeComponent();
             WordList.DataSource = _words;
+
+
         }
 
 
@@ -31,23 +35,26 @@ namespace Wordfind_Generator
         //Save settings to the file
         private void SaveFileDialog1_FileOk(object sender, CancelEventArgs e)
         {
+            _checklist.Clear();  //this clears the checklist to stop the checkbox
+                                 //list from growing when saving it to the puzzle file.
             string fileName = saveFileDialog1.FileName;
-            MakeCheckboxList();
-
             File.WriteAllText(fileName, "Cheklist:\n");
 
             //Save the checkbox list into the file
-            foreach(bool value in _checklist)
+
+            MakeCheckboxList();     //checks the puzzle direction settings boxes
+
+            foreach (bool value in _checklist)
             {
-                File.AppendAllText(fileName, value.ToString()+"\n");
+                File.AppendAllText(fileName, value.ToString() + "\n");
             }
 
             //Save the word list into the file
             File.AppendAllText(fileName, "\nWordlist:\n");
 
-            foreach(string str in _words)
+            foreach (string str in _words)
             {
-                File.AppendAllText(fileName, str+"\n");
+                File.AppendAllText(fileName, str + "\n");
             }
 
             //Save dimension settings
@@ -61,15 +68,16 @@ namespace Wordfind_Generator
 
         //Open the open dialog, load configuration settings/word list 
         private void LoadButton_Click(object sender, EventArgs e)
+
         {
             OpenFileDialog openFileDialog1 = new OpenFileDialog();
+
             DialogResult result = openFileDialog1.ShowDialog();
 
             //Load settings when OK is clicked
             if (result == DialogResult.OK)
             {
-                string name = openFileDialog1.FileName; 
-
+                string name = openFileDialog1.FileName;
                 try
                 {
                     StreamReader reader = File.OpenText(name);
@@ -78,7 +86,10 @@ namespace Wordfind_Generator
 
                     while ((line = reader.ReadLine()) != null)
                     {
-                        //Load Checkboxes
+                        _checklist.Clear();   // this clears out any previous checklist so "appending" to
+                                              // the list does not build the length beyond
+                                              // 8 boxes in the saved file.  "_checklist.Clear();"
+                                              //Load Checkboxes
                         if (line == "Cheklist:")
                         {
                             while ((line = reader.ReadLine()) != "")
@@ -113,13 +124,20 @@ namespace Wordfind_Generator
                             line = reader.ReadLine();
                             WidthPanel.Value = Convert.ToInt32(line);
                         }
-                    }                    
+
+                    }
+                    // close the stream in order to "save" to the filename which was
+                    // opened using the "LOAD" button. AA3M  3/11/2024  "reader.close();"
+                    reader.Close();
+
                 }
                 catch (IOException)
                 {
                     MessageBox.Show("An IOException has occurred.");
                 }
+
             }
+
         }
 
 
@@ -163,24 +181,24 @@ namespace Wordfind_Generator
         private void ModifyButton_Click(object sender, EventArgs e)
         {
             int selectedIndex = WordList.SelectedIndex;
-            
+
 
             //Replace word if a word is selected
             if (selectedIndex != -1)
             {
                 ModifyWord mod = new ModifyWord(WordList.GetItemText(WordList.SelectedItem));
-                
+
                 DialogResult dialogresult = mod.ShowDialog();
                 _words.Insert(selectedIndex, mod.getWord());
                 _words.RemoveAt(selectedIndex + 1);
-                
+
                 mod.Dispose();
             }
             else
                 MessageBox.Show("Select a word for modification.");
 
         }
-        
+
 
         //Removes word on button click, displays error if no word is selected
         private void RemoveButton_Click(object sender, EventArgs e)
@@ -200,10 +218,16 @@ namespace Wordfind_Generator
 
 
         //Clicking the generate puzzle button 
-        private void Generate_Click(object sender, EventArgs e)
+        public void Generate_Click(object sender, EventArgs e)
         {
-            _checklist.Clear();
-            MakeCheckboxList();            
+            MakeCheckboxList();
+
+
+            int localSerialNumber = ShowPuzzle.makeSerialNumber();   //need this to call the makeSerialNumber() method from within this method
+                                                                     // that creates the random serial number printed on the pages
+                                                                     //after hitting the Generate Puzzle button.
+            serialNumberString = localSerialNumber.ToString();       //provides a text string input for serial number text box
+
 
             int height = Convert.ToInt32(HeightPanel.Value);
             int width = Convert.ToInt32(WidthPanel.Value);
@@ -218,13 +242,15 @@ namespace Wordfind_Generator
 
             height = CheckHeight(length, height);
             width = CheckWidth(length, width);
-         
+
+
+
 
             //We can proceed to generate the puzzle if at least one directional checkbox is selected
             if (DirectionalsNotUnchecked())
             {
                 WordFindGeneration wordFind = new WordFindGeneration(_checklist, _words, height, width);
-                
+
                 wordFind.GenerateNewList();
                 wordFind.PopulateGrid();
                 wordFind.InitializePuzzleGrid();
@@ -237,7 +263,7 @@ namespace Wordfind_Generator
                 {
                     ShowPuzzle show = new ShowPuzzle(answersGrid, puzzleGrid, _words);
                     show.ShowDialog();
-                    
+
                     //The box is closed
                     show.Dispose();
                 }
@@ -245,7 +271,7 @@ namespace Wordfind_Generator
                 {
                     MessageBox.Show("The puzzle was unable to be generated due to too many words being into too small a puzzle grid. \n" +
                         "Please try again with either a shorter list or larger grid size.");
-                }                
+                }
             }
             else
                 MessageBox.Show("Please select at least one directional option.");
@@ -417,7 +443,7 @@ namespace Wordfind_Generator
 
         private void saveButton_MouseHover(object sender, EventArgs e)
         {
-            saveTip.SetToolTip(saveButton, "Save the current puzzle");
+            saveTip.SetToolTip(saveButton, "Save the current puzzle.");
         }
 
         private void generateButton_MouseHover(object sender, EventArgs e)
@@ -451,7 +477,7 @@ namespace Wordfind_Generator
 
         //Check the grid size is appropriate, otherwise we must resize
         private int CheckHeight(int length, int height)
-        {            
+        {
             if (length > height)
             {
                 height = length + 1;
@@ -461,7 +487,7 @@ namespace Wordfind_Generator
             }
             return height;
         }
-        
+
 
         private int CheckWidth(int length, int width)
         {
@@ -471,7 +497,7 @@ namespace Wordfind_Generator
                 WidthPanel.Value = length + 1;
                 MessageBox.Show("A word is too big, readjusted width to " +
                     width.ToString());
-            }            
+            }
             return width;
         }
 
@@ -480,7 +506,7 @@ namespace Wordfind_Generator
         {
             string wordlist = "";
 
-            foreach(string item in _words)
+            foreach (string item in _words)
             {
                 wordlist += item + "\r\n";
             }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 Wordfind Generator
 ==============
 
+// Original code collected from GitHub using "caraconrad Wordfind - Generator"  
+// Cara did 100% all of the heavy lifting on this one. Thank You Cara    de AA3M
+
 Just a simple tool to create wordfind puzzles.
 
 - Specify custom grid dimensions
 - Save and load word lists and settings
-- Export, copy, or print generated puzzles
+- Export, copy, or print generated puzzles with matching serial numbers
+
+- changed print routine to print only puzzle or answer sheets ShowPuzzle.cs buildPrintString() 
+- along with a serial number to match them using makeSerialNumber()
+- Corrected an exception error when saving back to the original loaded filename by adding 
+- reader.Close(); to the CreateWordFind.cs file (line 131)  3/15/2024  de AA3M
+- Added _checklist.Clear(); to CreateWordFind.cs file (line 38 ) to fix checkbox settings list upon saving 

--- a/ShowPuzzle.Designer.cs
+++ b/ShowPuzzle.Designer.cs
@@ -28,28 +28,30 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             this.closeButton = new System.Windows.Forms.Button();
             this.copyButton = new System.Windows.Forms.Button();
             this.printButton = new System.Windows.Forms.Button();
             this.PuzzleDisplay = new System.Windows.Forms.RichTextBox();
-            this.puzzleContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.puzzleContextMenu = new System.Windows.Forms.ContextMenuStrip();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.printToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyTip = new System.Windows.Forms.ToolTip(this.components);
-            this.printTip = new System.Windows.Forms.ToolTip(this.components);
-            this.closeTip = new System.Windows.Forms.ToolTip(this.components);
+            this.copyTip = new System.Windows.Forms.ToolTip();
+            this.printTip = new System.Windows.Forms.ToolTip();
+            this.closeTip = new System.Windows.Forms.ToolTip();
             this.ExportButton = new System.Windows.Forms.Button();
             this.ToggleButton = new System.Windows.Forms.Button();
             this.exportDialog = new System.Windows.Forms.SaveFileDialog();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.puzzleContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // closeButton
             // 
-            this.closeButton.Location = new System.Drawing.Point(292, 463);
+            this.closeButton.Location = new System.Drawing.Point(925, 1318);
+            this.closeButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(106, 26);
+            this.closeButton.Size = new System.Drawing.Size(336, 74);
             this.closeButton.TabIndex = 0;
             this.closeButton.Text = "Close";
             this.closeButton.UseVisualStyleBackColor = true;
@@ -58,9 +60,10 @@
             // 
             // copyButton
             // 
-            this.copyButton.Location = new System.Drawing.Point(36, 399);
+            this.copyButton.Location = new System.Drawing.Point(114, 1136);
+            this.copyButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.copyButton.Name = "copyButton";
-            this.copyButton.Size = new System.Drawing.Size(106, 26);
+            this.copyButton.Size = new System.Drawing.Size(336, 74);
             this.copyButton.TabIndex = 1;
             this.copyButton.Text = "Copy to Clipboard";
             this.copyButton.UseVisualStyleBackColor = true;
@@ -69,9 +72,10 @@
             // 
             // printButton
             // 
-            this.printButton.Location = new System.Drawing.Point(204, 399);
+            this.printButton.Location = new System.Drawing.Point(646, 1136);
+            this.printButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.printButton.Name = "printButton";
-            this.printButton.Size = new System.Drawing.Size(106, 26);
+            this.printButton.Size = new System.Drawing.Size(336, 74);
             this.printButton.TabIndex = 2;
             this.printButton.Text = "Print...";
             this.printButton.UseVisualStyleBackColor = true;
@@ -81,41 +85,44 @@
             // PuzzleDisplay
             // 
             this.PuzzleDisplay.ContextMenuStrip = this.puzzleContextMenu;
-            this.PuzzleDisplay.Location = new System.Drawing.Point(29, 44);
+            this.PuzzleDisplay.Location = new System.Drawing.Point(97, 108);
+            this.PuzzleDisplay.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.PuzzleDisplay.Name = "PuzzleDisplay";
             this.PuzzleDisplay.ReadOnly = true;
-            this.PuzzleDisplay.Size = new System.Drawing.Size(458, 344);
+            this.PuzzleDisplay.Size = new System.Drawing.Size(1442, 972);
             this.PuzzleDisplay.TabIndex = 3;
             this.PuzzleDisplay.Text = "";
             this.PuzzleDisplay.WordWrap = false;
             // 
             // puzzleContextMenu
             // 
+            this.puzzleContextMenu.ImageScalingSize = new System.Drawing.Size(48, 48);
             this.puzzleContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem,
             this.printToolStripMenuItem});
             this.puzzleContextMenu.Name = "puzzleContextMenu";
-            this.puzzleContextMenu.Size = new System.Drawing.Size(101, 48);
+            this.puzzleContextMenu.Size = new System.Drawing.Size(177, 116);
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(100, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(176, 56);
             this.copyToolStripMenuItem.Text = "copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // printToolStripMenuItem
             // 
             this.printToolStripMenuItem.Name = "printToolStripMenuItem";
-            this.printToolStripMenuItem.Size = new System.Drawing.Size(100, 22);
+            this.printToolStripMenuItem.Size = new System.Drawing.Size(176, 56);
             this.printToolStripMenuItem.Text = "print";
             this.printToolStripMenuItem.Click += new System.EventHandler(this.printToolStripMenuItem_Click);
             // 
             // ExportButton
             // 
-            this.ExportButton.Location = new System.Drawing.Point(374, 399);
+            this.ExportButton.Location = new System.Drawing.Point(1184, 1136);
+            this.ExportButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.ExportButton.Name = "ExportButton";
-            this.ExportButton.Size = new System.Drawing.Size(106, 26);
+            this.ExportButton.Size = new System.Drawing.Size(336, 74);
             this.ExportButton.TabIndex = 4;
             this.ExportButton.Text = "Export...";
             this.ExportButton.UseVisualStyleBackColor = true;
@@ -123,9 +130,10 @@
             // 
             // ToggleButton
             // 
-            this.ToggleButton.Location = new System.Drawing.Point(126, 458);
+            this.ToggleButton.Location = new System.Drawing.Point(399, 1304);
+            this.ToggleButton.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.ToggleButton.Name = "ToggleButton";
-            this.ToggleButton.Size = new System.Drawing.Size(102, 36);
+            this.ToggleButton.Size = new System.Drawing.Size(323, 102);
             this.ToggleButton.TabIndex = 5;
             this.ToggleButton.Text = "Toggle Answers";
             this.ToggleButton.UseVisualStyleBackColor = true;
@@ -135,21 +143,47 @@
             // 
             this.exportDialog.FileOk += new System.ComponentModel.CancelEventHandler(this.exportDialog_FileOk);
             // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(345, 1238);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(83, 44);
+            this.textBox1.TabIndex = 6;
+            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(107, 1245);
+            this.label6.Margin = new System.Windows.Forms.Padding(10, 0, 10, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(222, 37);
+            this.label6.TabIndex = 17;
+            this.label6.Text = "Serial Number";
+            this.label6.Click += new System.EventHandler(this.label3_Click);
+            // 
             // ShowPuzzle
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(19F, 37F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(521, 522);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(1650, 1486);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.textBox1);
             this.Controls.Add(this.ToggleButton);
             this.Controls.Add(this.ExportButton);
             this.Controls.Add(this.PuzzleDisplay);
             this.Controls.Add(this.printButton);
             this.Controls.Add(this.copyButton);
             this.Controls.Add(this.closeButton);
+            this.Margin = new System.Windows.Forms.Padding(10, 9, 10, 9);
             this.Name = "ShowPuzzle";
             this.Text = "Puzzle View";
             this.puzzleContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -168,5 +202,7 @@
         private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem printToolStripMenuItem;
         private System.Windows.Forms.SaveFileDialog exportDialog;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.Label label6;
     }
 }

--- a/ShowPuzzle.cs
+++ b/ShowPuzzle.cs
@@ -2,17 +2,19 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Printing;
-using System.Windows.Forms;
 using System.IO;
-
+using System.Windows.Forms;
 namespace Wordfind_Generator
 {
     public partial class ShowPuzzle : Form
     {
 
+
         private string _answers, _puzzle;
         private int toggle;
         private BindingList<string> _items;
+
+        public static int serialNumber; //public static int made the variable accessible from other methods in this class.
 
         public ShowPuzzle(string answers, string puzzle, BindingList<string> items)
         {
@@ -26,7 +28,11 @@ namespace Wordfind_Generator
 
             PuzzleDisplay.Font = new Font("Courier New", 14);
             PuzzleDisplay.AppendText(_puzzle);
+
+            textBox1.Text = serialNumber.ToString(); //used to convert random number and display in the TEXTBOX
+
         }
+
 
         //Opens print dialog
         private void printButton_Click(object sender, EventArgs e)
@@ -35,13 +41,37 @@ namespace Wordfind_Generator
         }
 
 
+        public static int makeSerialNumber()   //this is called from within the Generate_Click method !!!!!
+        {
+
+            Random rnd = new Random();
+            serialNumber = rnd.Next(100, 999);
+            return ShowPuzzle.serialNumber;
+        }
+
+
         //Builds a string containing puzzle and wordlist
         private string buildPrintString()
         {
-            int columnCount = 0;
-            string printerString = _puzzle + "\r\n";
 
-            foreach(string item in _items)
+            int columnCount = 0;
+
+            // this modification allows you to print the puzzle and answer sheet separately.
+            //string printerString = _puzzle + "\r\n";    //cara's original  2/5/2024  de AA3M
+            string printerString = _puzzle;
+
+            if (toggle == 0)
+            {
+                printerString = _puzzle + "\r\n" + "Serial Number " + serialNumber;
+            }
+            else if (toggle == 1)
+            {
+                printerString = _answers + "\r\n" + "Serial Number " + serialNumber;
+            }
+
+
+
+            foreach (string item in _items)
             {
                 if (columnCount % 3 == 0)
                 {
@@ -51,10 +81,11 @@ namespace Wordfind_Generator
                 printerString += item + "\t";
                 columnCount++;
             }
+
             return printerString;
         }
 
-        //Close window
+
         private void cancelButton_Click(object sender, EventArgs e)
         {
             this.Close();
@@ -68,7 +99,7 @@ namespace Wordfind_Generator
 
         private void printButton_MouseHover(object sender, EventArgs e)
         {
-            printTip.SetToolTip(printButton, "Print the puzzle");
+            printTip.SetToolTip(printButton, "Print the puzzle view shown in window above \n use the Toggle Answers button to switch views.");
         }
 
         private void closeButton_MouseHover(object sender, EventArgs e)
@@ -136,7 +167,7 @@ namespace Wordfind_Generator
             string s = buildPrintString();
 
             PrintDocument p = new PrintDocument();
-            p.PrintPage += delegate(object sender1, PrintPageEventArgs e1)
+            p.PrintPage += delegate (object sender1, PrintPageEventArgs e1)
             {
                 e1.Graphics.DrawString(s, new Font("Courier New", 14), new SolidBrush(Color.Black),
                     new RectangleF(0, 0, p.DefaultPageSettings.PrintableArea.Width,
@@ -159,11 +190,32 @@ namespace Wordfind_Generator
             exportDialog.ShowDialog();
         }
 
+        private void label3_Click(object sender, EventArgs e)
+        {
+            // keep this empty method
+        }
+
+        private void textBox1_TextChanged(object sender, EventArgs e)
+        {
+
+        }
+
         private void exportDialog_FileOk(object sender, CancelEventArgs e)
         {
-            string name = exportDialog.FileName + ".txt";
 
-            File.WriteAllText(name, _puzzle);            
+            string name = exportDialog.FileName + ".txt";
+            File.WriteAllText(name, _puzzle);
+            File.AppendAllText(name, "\n\n\n\n");
+            File.AppendAllText(name, _answers);
+
         }
+
+
+
+
+
+
+
+
     }
 }

--- a/Wordfind_Generator.csproj.user
+++ b/Wordfind_Generator.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectView>ShowAllFiles</ProjectView>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION

- changed print routine to print only puzzle or answer sheets ShowPuzzle.cs buildPrintString() 
- along with a serial number to match them using makeSerialNumber()
- Corrected an exception error when saving back to the original loaded filename by adding 
- reader.Close(); to the CreateWordFind.cs file (line 131)  3/15/2024  de AA3M
- Added _checklist.Clear(); to CreateWordFind.cs file (line 38 ) to fix checkbox settings list upon saving 